### PR TITLE
fix: QRectF -> QRect build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .cache
+build

--- a/src/slidingnotificationseffect.cpp
+++ b/src/slidingnotificationseffect.cpp
@@ -70,7 +70,7 @@ void SlidingNotificationsEffect::postPaintScreen()
 {
     for (auto it = m_animations.begin(); it != m_animations.end();) {
         EffectWindow *window = it.key();
-        effects->addRepaint(it->clip.translated(window->pos()));
+        effects->addRepaint(it->clip.translated(window->pos()).toRect());
 
         if (it->timeline.done()) {
             unforceBlurEffect(window);


### PR DESCRIPTION
https://invent.kde.org/plasma/kwin/-/merge_requests/2746

This causes build errors on 5.25.5 and will also result in errors on 5.26

Not sure if the linked PR is the right one, but apparently it also causes issues on 5.25.5 - as I can't build the package due to the QRectF -> QRect error on 5.25.5.

Also added the build folder to the gitignore ^^

This PR was tested on 5.25.5 and 5.25.90 (5.26 Beta)